### PR TITLE
Google calendar additional config

### DIFF
--- a/app/controllers/api/v1/events_controller.rb
+++ b/app/controllers/api/v1/events_controller.rb
@@ -3,16 +3,13 @@ require "google/apis/calendar_v3"
 class Api::V1::EventsController < ApiController
   def index
     auth = Signet::OAuth2::Client.new(
-      # authorization_uri: 'https://oauth2.googleapis.com/token',
       token_credential_uri: 'https://oauth2.googleapis.com/token',
       access_token: current_user.access_token,
       client_id: ENV["GOOGLE_CLIENT_ID"],
       client_secret: ENV["GOOGLE_CLIENT_SECRET"],
       refresh_token: current_user.refresh_token
-      # grant_type: "authorization_code"
     )
     auth.expires_in = 1.week.from_now
-    # auth.fetch_access_token!
     calendar = Google::Apis::CalendarV3::CalendarService.new
     calendar.authorization = auth
     calendar.authorization.refresh!

--- a/app/controllers/api/v1/notifications_controller.rb
+++ b/app/controllers/api/v1/notifications_controller.rb
@@ -2,28 +2,28 @@ require "google/apis/calendar_v3"
 
 class Api::V1::NotificationsController < ApiController
   def index
-    # auth = Signet::OAuth2::Client.new(
-    #   authorization_uri: 'https://oauth2.googleapis.com/token',
-    #   token_credential_uri: 'https://oauth2.googleapis.com/token',
-    #   access_token: current_user.access_token,
-    #   client_id: ENV["GOOGLE_CLIENT_ID"],
-    #   client_secret: ENV["GOOGLE_CLIENT_SECRET"],
-    #   refresh_token: current_user.refresh_token,
-    #   grant_type: "authorization_code"
-    # )
-    # auth.fetch_access_token!
-    # calendar = Google::Apis::CalendarV3::CalendarService.new
-    # calendar.authorization = auth
-    # events = calendar.list_events("primary",
-    #   time_max: (DateTime.now).rfc3339,
-    #   single_events: true,
-    #   order_by: "startTime",
-    #   time_min: (DateTime.now-1).rfc3339
-    # )
-    #
-    # mailchimpData = HTTParty.get('https://us20.api.mailchimp.com/3.0/lists/fa6ed98e87/members',
-    #   basic_auth: {username: ENV["MAILCHIMP_USERNAME"], password: ENV["MAILCHIMP_PASSWORD"]}
-    # )
+    auth = Signet::OAuth2::Client.new(
+      token_credential_uri: 'https://oauth2.googleapis.com/token',
+      access_token: current_user.access_token,
+      client_id: ENV["GOOGLE_CLIENT_ID"],
+      client_secret: ENV["GOOGLE_CLIENT_SECRET"],
+      refresh_token: current_user.refresh_token
+    )
+    auth.expires_in = 1.week.from_now
+    calendar = Google::Apis::CalendarV3::CalendarService.new
+    calendar.authorization = auth
+    calendar.authorization.refresh!
+
+    events = calendar.list_events("primary",
+      time_max: (DateTime.now).rfc3339,
+      single_events: true,
+      order_by: "startTime",
+      time_min: (DateTime.now-1).rfc3339
+    )
+
+    mailchimpData = HTTParty.get('https://us20.api.mailchimp.com/3.0/lists/fa6ed98e87/members',
+      basic_auth: {username: ENV["MAILCHIMP_USERNAME"], password: ENV["MAILCHIMP_PASSWORD"]}
+    )
 
     notification_list = []
     recentSummaries = []


### PR DESCRIPTION
1. Updated from_omniauth method to persist new refresh tokens
2. Fixed API code for google calendar to use the correct access token